### PR TITLE
add a use_inotify option. On by default for linux.

### DIFF
--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -1,3 +1,4 @@
 -r requirements.txt
 behave==1.2.4
 selenium==2.45.0
+pyinotify==0.9.5


### PR DESCRIPTION
This improves startup time by a little bit, since we now don't keep
track of each file's mtime, but instead let the Linux kernel handle that
for us. We also get a lighter runserver process, since we don't have to
keep stating all the files we keep track to see if they've been
modified. Restarting should also be a tad faster, since we now don't
have to use time.sleep in-between stat calls.

We also add pyinotify as a dependency.
